### PR TITLE
fix: include <algorithm> in group.h

### DIFF
--- a/src/logid/config/group.h
+++ b/src/logid/config/group.h
@@ -18,6 +18,7 @@
 #ifndef LOGID_CONFIG_GROUP_H
 #define LOGID_CONFIG_GROUP_H
 
+#include <algorithm>
 #include <libconfig.h++>
 #include <type_traits>
 #include <functional>


### PR DESCRIPTION
For context, see [1].

[1]: https://github.com/PixlOne/logiops/pull/415